### PR TITLE
Fixing issue with dot in unique hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+* Prevent method `getUniquePlaceholder()` hash from generating strings with a `dot` in it which will break doctrine query builder
+
 -
 
 

--- a/Input/FilterField.php
+++ b/Input/FilterField.php
@@ -141,7 +141,7 @@ class FilterField implements ApplicableToQueryBuilder
      */
     private function getUniquePlaceholder(): string
     {
-        return 'filter_' . $this->getName() . '_' . uniqid('', true);
+        return 'filter_' . $this->getName() . '_' . sha1(uniqid('', true));
     }
 
     /**


### PR DESCRIPTION
Since 2.0 `getUniquePlaceholder()` comes with more entropy via `uniqid()`.
This also adds a dot to the string which will later be used as a placeholder Parameter by doctrine.
But using dots in a placeholder string is forbidden, as doctrine tries to interpret it as an entity property access -> the parser will fail

```
$queryBuilder = $doctrine->createQueryBuilder();
$csv = $queryBuilder
    ->select('csv')
    ->from(\App\Entity\CsvFile::class, 'csv')
    ->where('csv.status = :test.123')
    ->setParameter(':test.123', 'pending')
    ->getQuery();
```

Invalid because `:test.123` will be split by the doctrine lexer.
