### PR TITLE
Feature/add support for new doctrine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.6] - 2021-05-20
+
+### Changed
+
+- Doctrine ManagerRegistry in ResultConverter
+
 ## [2.0.5] - 2020-09-21
 
 ### Fixed

--- a/ParamConverter/ResultConverter.php
+++ b/ParamConverter/ResultConverter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shopping\ApiTKUrlBundle\ParamConverter;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use InvalidArgumentException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;

--- a/composer.lock
+++ b/composer.lock
@@ -3142,22 +3142,22 @@
         },
         {
             "name": "captainhook/plugin-composer",
-            "version": "5.2.1",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/CaptainHookPhp/plugin-composer.git",
-                "reference": "3e122bc01808d2411307db09f8c14efab57fc6fb"
+                "url": "https://github.com/captainhookphp/plugin-composer.git",
+                "reference": "def8812945e0767a45fe0e4db5ed255b7093600a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CaptainHookPhp/plugin-composer/zipball/3e122bc01808d2411307db09f8c14efab57fc6fb",
-                "reference": "3e122bc01808d2411307db09f8c14efab57fc6fb",
+                "url": "https://api.github.com/repos/captainhookphp/plugin-composer/zipball/def8812945e0767a45fe0e4db5ed255b7093600a",
+                "reference": "def8812945e0767a45fe0e4db5ed255b7093600a",
                 "shasum": ""
             },
             "require": {
                 "captainhook/captainhook": "^5.0",
-                "composer-plugin-api": "^1.1",
-                "php": "^7.1"
+                "composer-plugin-api": "^1.1|^2.0",
+                "php": ">=7.1"
             },
             "require-dev": {
                 "composer/composer": "*"
@@ -3189,7 +3189,11 @@
                 }
             ],
             "description": "Composer-Plugin handling your git-hooks",
-            "time": "2020-05-08T15:15:33+00:00"
+            "support": {
+                "issues": "https://github.com/captainhookphp/plugin-composer/issues",
+                "source": "https://github.com/captainhookphp/plugin-composer/tree/5.3.0"
+            },
+            "time": "2021-05-06T15:55:15+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -5496,5 +5500,5 @@
         "php": "^7.1.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This pull request will change the namespace usage of the Doctrine ManagerRegistry in the ResultConverter. Furthermore the captainhook/plugin-composer was updated due to composer 2.