### PR TITLE
add support for sensio/framework-extra-bundle 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2021-08-30
+
+### Added
+
+- Support for sensio/framework-extra-bundle 6.x
+
 ## [2.2.0] - 2021-06-28
 
 ### Added 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "check24/apitk-url-bundle",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "type": "symfony-bundle",
   "description": "This bundle provides filter, sorting and pagination for RESTful API's",
@@ -36,7 +36,7 @@
     "symfony/framework-bundle": ">=4.3 <6.0",
     "doctrine/annotations": "^1.8",
     "nelmio/api-doc-bundle": "^3.4",
-    "sensio/framework-extra-bundle": "^5.1",
+    "sensio/framework-extra-bundle": "^5.1 || ^6.0",
     "check24/apitk-common-bundle": "^2.2.0",
     "check24/apitk-header-bundle": "^2.2.0"
   },


### PR DESCRIPTION
sensio/framework-extra-bundle did remove the dependency on `nyholm/psr7` in 6.x, which this bundle does not rely upon.
See https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/CHANGELOG.md

This change allows implementing projects to use the most recent version of sensio/framework-extra-bundle again.