### PR TITLE
fix_sorting_filtering: Handle sorting and filtering only when respect…

### DIFF
--- a/EventListener/AnnotationListener.php
+++ b/EventListener/AnnotationListener.php
@@ -75,11 +75,15 @@ class AnnotationListener
 
         // Filters
         $filters = array_filter($methodAnnotations, static function ($annotation) { return $annotation instanceof Api\Filter; });
-        $this->apiService->handleAllowedFilters($filters);
+        if (count($filters) > 0) {
+            $this->apiService->handleAllowedFilters($filters);
+        }
 
         // Sorts
         $sorts = array_filter($methodAnnotations, static function ($annotation) { return $annotation instanceof Api\Sort; });
-        $this->apiService->handleAllowedSorts($sorts);
+        if (count($sorts) > 0) {
+            $this->apiService->handleAllowedSorts($sorts);
+        }
 
         // Pagination
         /** @var Api\Pagination[] $paginations */

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,11 @@
       "url": "https://github.com/byWulf/apitk-header-bundle.git"
     }
   ],
+  "config": {
+    "allow-plugins": {
+      "captainhook/plugin-composer": true
+    }
+  },
   "require": {
     "php": "^7.4 || ^8.0",
     "symfony/config": ">=5.3 <6.0",


### PR DESCRIPTION
…ive annotations are available

Context: handleAllowedSorts() was triggerd for easyAdmin controllers(dont't contain any bundle annotations) triggered an error. Example: Sort name with direction ASC is not allowed in this request. Available sorts: